### PR TITLE
Idea/array backend class

### DIFF
--- a/odl/array_API_support/element_wise.py
+++ b/odl/array_API_support/element_wise.py
@@ -96,7 +96,7 @@ def _apply_element_wise(x1, operation: str, out=None, **kwargs):
     # We make sure to return an element of the right type: 
     # for instance, if two spaces have a int dtype, the result of the division 
     # of one of their element by another return should be of float dtype
-    return x1.space.astype(x1.space.get_dtype_identifier(array=result)).element(result) 
+    return x1.space.astype(x1.space.array_backend.get_dtype_identifier(array=result)).element(result) 
 
 def abs(x, out=None):
     """Calculates the absolute value for each element `x_i` of the input array

--- a/odl/space/base_tensors.py
+++ b/odl/space/base_tensors.py
@@ -21,6 +21,7 @@ from odl.set.sets import ComplexNumbers, RealNumbers
 from odl.set.space import (
     LinearSpace, LinearSpaceElement, LinearSpaceTypeError,
     SupportedNumOperationParadigms, NumOperationParadigmSupport)
+from odl.util.vectorization import ArrayBackend, registered_array_backends
 from odl.util import (
     array_str, indent, is_complex_floating_dtype,
     is_numeric_dtype, is_real_floating_dtype, safe_int_conv,
@@ -204,6 +205,10 @@ class TensorSpace(LinearSpace):
                     )
     
     ########## Attributes ##########
+    @property
+    def array_backend(self) -> ArrayBackend:
+        return registered_array_backends[self.impl]
+
     @property
     def array_constructor(self):
         """Name of the function called to create an array of this tensor space.
@@ -1129,6 +1134,10 @@ class Tensor(LinearSpaceElement):
     ######### static methods #########
 
     ######### Attributes #########
+    @property
+    def array_backend(self) -> ArrayBackend:
+        return self.space.array_backend
+
     @property
     def array_namespace(self) -> ModuleType:
         """Name of the array_namespace of this tensor.

--- a/odl/space/base_tensors.py
+++ b/odl/space/base_tensors.py
@@ -85,26 +85,26 @@ class TensorSpace(LinearSpace):
             are added *to the left* of ``shape``.
         """
         # Handle shape and dtype, taking care also of dtypes with shape        
-        self.parse_dtype(dtype)
+        self._init_dtype(dtype)
 
-        self.parse_shape(shape, dtype)
+        self._init_shape(shape, dtype)
 
-        self.parse_device(device)
+        self._init_device(device)
 
         self.__use_in_place_ops = kwargs.pop('use_in_place_ops', True)
   
-        self.parse_weighting(**kwargs)
+        self._init_weighting(**kwargs)
 
-        field = self.parse_field()
+        field = self._init_field()
 
         LinearSpace.__init__(self, field)
 
     ################ Init Methods, Non static ################
-    def parse_device(self, device:str):
+    def _init_device(self, device:str):
         odl.check_device(self.impl, device)
         self.__device = device 
 
-    def parse_dtype(self, dtype:str | int | float | complex):
+    def _init_dtype(self, dtype:str | int | float | complex):
         """
         Process the dtype argument. This parses the (str or Number) dtype input argument to a backend.dtype and sets two attributes
 
@@ -137,7 +137,7 @@ class TensorSpace(LinearSpace):
         else:
             raise ValueError(f"The dtype must be in {available_dtypes.keys()} or must be a dtype of the backend, but {dtype} was provided")
 
-    def parse_shape(self, shape, dtype):
+    def _init_shape(self, shape, dtype):
         # Handle shape and dtype, taking care also of dtypes with shape
         try:
             shape, shape_in = tuple(safe_int_conv(s) for s in shape), shape
@@ -154,7 +154,7 @@ class TensorSpace(LinearSpace):
         # <!> this is likely to break in Pytorch
         self.__shape = np.dtype(dtype).shape + shape
 
-    def parse_field(self):
+    def _init_field(self):
         if self.dtype_identifier in TYPE_PROMOTION_REAL_TO_COMPLEX:
             # real includes non-floating-point like integers
             field = RealNumbers()
@@ -177,7 +177,7 @@ class TensorSpace(LinearSpace):
             field = None
         return field
     
-    def parse_weighting(self, **kwargs):
+    def _init_weighting(self, **kwargs):
         weighting = kwargs.pop("weighting", None)    
         if weighting is None:
             self.__weighting = odl.space_weighting(impl=self.impl, device=self.device, **kwargs)

--- a/odl/space/base_tensors.py
+++ b/odl/space/base_tensors.py
@@ -21,7 +21,7 @@ from odl.set.sets import ComplexNumbers, RealNumbers
 from odl.set.space import (
     LinearSpace, LinearSpaceElement, LinearSpaceTypeError,
     SupportedNumOperationParadigms, NumOperationParadigmSupport)
-from odl.util.vectorization import ArrayBackend, lookup_array_backend
+from odl.array_API_support import ArrayBackend, lookup_array_backend
 from odl.util import (
     array_str, indent, is_complex_floating_dtype,
     is_numeric_dtype, is_real_floating_dtype, safe_int_conv,

--- a/odl/space/base_tensors.py
+++ b/odl/space/base_tensors.py
@@ -35,6 +35,31 @@ from .weighting import Weighting
 
 __all__ = ('TensorSpace',)
 
+def default_dtype(array_backend: ArrayBackend, field=None):
+    """Return the default data type for a given field.
+
+    Parameters
+    ----------
+    array_backend : `ArrayBackend`
+        The implementation, defining what dtypes are available.
+    field : `Field`, optional
+        Set of numbers to be represented by a data type.
+        Currently supported : `RealNumbers`, `ComplexNumbers`
+        The default ``None`` means `RealNumbers`
+
+    Returns
+    -------
+    dtype :
+        Backend data type specifier.
+    """
+    if field is None or field == RealNumbers():
+        return array_backend.available_dtypes['float32']
+    elif field == ComplexNumbers():
+       return array_backend.available_dtypes['complex64']
+    else:
+        raise ValueError('no default data type defined for field {}'
+                         ''.format(field))
+
 class TensorSpace(LinearSpace):
 
     """Base class for sets of tensors of arbitrary data type.
@@ -518,31 +543,6 @@ class TensorSpace(LinearSpace):
         else:
             return self._astype(dtype_identifier)
         
-    def default_dtype(self, field=None):
-        """Return the default data type for a given field.
-
-        This method should be overridden by subclasses.
-
-        Parameters
-        ----------
-        field : `Field`, optional
-            Set of numbers to be represented by a data type.
-            Currently supported : `RealNumbers`, `ComplexNumbers`
-            The default ``None`` means `RealNumbers`
-
-        Returns
-        -------
-        dtype :
-            Backend data type specifier.
-        """
-        if field is None or field == RealNumbers():
-            return self.array_backend.available_dtypes['float32']
-        elif field == ComplexNumbers():
-           return self.array_backend.available_dtypes['complex64']
-        else:
-            raise ValueError('no default data type defined for field {}'
-                             ''.format(field))
-        
     def element(self, inp=None, device=None, copy=True):
         def wrapped_array(arr):
             if arr.shape != self.shape:
@@ -791,7 +791,7 @@ class TensorSpace(LinearSpace):
 
         if (ctor_name == 'tensor_space' or
                 not self.dtype_identifier in SCALAR_DTYPES or
-                self.dtype != self.default_dtype(self.field)):
+                self.dtype != default_dtype(self.array_backend, self.field)):
             optargs = [('dtype', self.dtype_identifier, '')]
             if self.dtype_identifier in (AVAILABLE_DTYPES):
                 optmod = '!s'

--- a/odl/space/base_tensors.py
+++ b/odl/space/base_tensors.py
@@ -335,7 +335,7 @@ class TensorSpace(LinearSpace):
     @property
     def element_type(self):
         """Type of elements in this space: `Tensor`."""
-        return Tensor
+        raise NotImplementedError
     
     @property
     def examples(self):
@@ -1103,12 +1103,6 @@ class TensorSpace(LinearSpace):
 class Tensor(LinearSpaceElement):
 
     """Abstract class for representation of `TensorSpace` elements."""
-    def __init__(self, space, data):
-        """Initialize a new instance."""
-        # Tensor.__init__(self, space)
-        LinearSpaceElement.__init__(self, space)
-        self.__data = data
-
     ######### static methods #########
 
     ######### Attributes #########
@@ -1126,8 +1120,8 @@ class Tensor(LinearSpaceElement):
     
     @property
     def data(self):
-        """The `numpy.ndarray` representing the data of ``self``."""
-        return self.__data
+        """The backend-specific array representing the data of ``self``."""
+        raise NotImplementedError("abstract method")
     
     @property
     def device(self):
@@ -1963,10 +1957,7 @@ class Tensor(LinearSpaceElement):
     def _assign(self, other, avoid_deep_copy):
         """Assign the values of ``other``, which is assumed to be in the
         same space, to ``self``."""
-        if avoid_deep_copy:
-            self.__data = other.__data
-        else:
-            self.__data[:] = other.__data
+        raise NotImplementedError("abstract method")
 
 if __name__ == '__main__':
     from odl.util.testutils import run_doctests

--- a/odl/space/base_tensors.py
+++ b/odl/space/base_tensors.py
@@ -152,10 +152,10 @@ class TensorSpace(LinearSpace):
             self.__dtype_identifier = dtype
             self.__dtype = available_dtypes[dtype]
         ### If the check has failed, i.e the dtype is not a Key of the available_dtypes dict or a python scalar, we try to parse the dtype 
-        ### as a string using the self.get_dtype_identifier(dtype=dtype) call: This is for the situation where the dtype passed is
+        ### as a string using the get_dtype_identifier(dtype=dtype) call: This is for the situation where the dtype passed is
         ### in the .values() of available_dtypes dict (something like 'numpy.float32')
         elif dtype in available_dtypes.values():
-            self.__dtype_identifier = self.get_dtype_identifier(dtype=dtype)
+            self.__dtype_identifier = self.array_backend.get_dtype_identifier(dtype=dtype)
             self.__dtype = dtype
             # If that fails, we throw an error: the dtype is not a python scalar dtype, not a string describing the dtype or the 
             # backend call to parse the dtype has failed.
@@ -509,10 +509,10 @@ class TensorSpace(LinearSpace):
             dtype_identifier = dtype
             dtype = available_dtypes[dtype]
         ### If the check has failed, i.e the dtype is not a Key of the available_dtypes dict or a python scalar, we try to parse the dtype 
-        ### as a string using the self.get_dtype_identifier(dtype=dtype) call: This is for the situation where the dtype passed is
+        ### as a string using the get_dtype_identifier(dtype=dtype) call: This is for the situation where the dtype passed is
         ### in the .values() of available_dtypes dict (something like 'numpy.float32')
-        elif self.get_dtype_identifier(dtype=dtype) in available_dtypes:
-            dtype_identifier = self.get_dtype_identifier(dtype=dtype)
+        elif self.array_backend.get_dtype_identifier(dtype=dtype) in available_dtypes:
+            dtype_identifier = self.array_backend.get_dtype_identifier(dtype=dtype)
             dtype = available_dtypes[dtype_identifier]
             # If that fails, we throw an error: the dtype is not a python scalar dtype, not a string describing the dtype or the 
             # backend call to parse the dtype has failed.
@@ -1089,7 +1089,7 @@ class TensorSpace(LinearSpace):
                 elif isinstance(x2, (int, float, complex)):
                     result_data = fn(x1.data, x2, out.data)
                     
-            return self.astype(self.get_dtype_identifier(array=result_data)).element(result_data) 
+            return self.astype(self.array_backend.get_dtype_identifier(array=result_data)).element(result_data) 
 
         assert isinstance(x1, Tensor), 'Left operand is not an ODL Tensor'
         assert isinstance(x2, Tensor), 'Right operand is not an ODL Tensor'
@@ -1099,8 +1099,6 @@ class TensorSpace(LinearSpace):
         else:
             return getattr(odl, combinator)(x1, x2, out)
         
-    def get_dtype_identifier(self, **kwargs):
-        raise NotImplementedError  
 
 class Tensor(LinearSpaceElement):
 

--- a/odl/space/base_tensors.py
+++ b/odl/space/base_tensors.py
@@ -21,7 +21,7 @@ from odl.set.sets import ComplexNumbers, RealNumbers
 from odl.set.space import (
     LinearSpace, LinearSpaceElement, LinearSpaceTypeError,
     SupportedNumOperationParadigms, NumOperationParadigmSupport)
-from odl.util.vectorization import ArrayBackend, registered_array_backends
+from odl.util.vectorization import ArrayBackend, lookup_array_backend
 from odl.util import (
     array_str, indent, is_complex_floating_dtype,
     is_numeric_dtype, is_real_floating_dtype, safe_int_conv,
@@ -207,7 +207,7 @@ class TensorSpace(LinearSpace):
     ########## Attributes ##########
     @property
     def array_backend(self) -> ArrayBackend:
-        return registered_array_backends[self.impl]
+        return lookup_array_backend(self.impl)
 
     @property
     def array_constructor(self):

--- a/odl/space/base_tensors.py
+++ b/odl/space/base_tensors.py
@@ -530,11 +530,11 @@ class TensorSpace(LinearSpace):
 
         if dtype_identifier in FLOAT_DTYPES + COMPLEX_DTYPES:
             # Caching for real and complex versions (exact dtype mappings)
-            if dtype == self.__real_dtype:
+            if dtype == self.real_dtype:
                 if self.__real_space is None:
                     self.__real_space = self._astype(dtype_identifier)
                 return self.__real_space
-            elif dtype == self.__complex_dtype:
+            elif dtype == self.complex_dtype:
                 if self.__complex_space is None:
                     self.__complex_space = self._astype(dtype_identifier)
                 return self.__complex_space

--- a/odl/space/base_tensors.py
+++ b/odl/space/base_tensors.py
@@ -53,9 +53,9 @@ def default_dtype(array_backend: ArrayBackend, field=None):
         Backend data type specifier.
     """
     if field is None or field == RealNumbers():
-        return array_backend.available_dtypes['float32']
+        return array_backend.available_dtypes['float64']
     elif field == ComplexNumbers():
-       return array_backend.available_dtypes['complex64']
+       return array_backend.available_dtypes['complex128']
     else:
         raise ValueError('no default data type defined for field {}'
                          ''.format(field))

--- a/odl/space/npy_tensors.py
+++ b/odl/space/npy_tensors.py
@@ -13,6 +13,7 @@ from future.utils import native
 
 import numpy as np
 
+from odl.set.space import LinearSpaceElement
 from odl.space.base_tensors import Tensor, TensorSpace
 from odl.util import is_numeric_dtype
 from odl.util.vectorization import ArrayBackend
@@ -267,6 +268,17 @@ class NumpyTensor(Tensor):
 
     """Representation of a `NumpyTensorSpace` element."""
     
+    def __init__(self, space, data):
+        """Initialize a new instance."""
+        # Tensor.__init__(self, space)
+        LinearSpaceElement.__init__(self, space)
+        self.__data = data
+
+    @property
+    def data(self):
+        """The `numpy.ndarray` representing the data of ``self``."""
+        return self.__data
+    
     @property
     def data_ptr(self):
         """A raw pointer to the data container of ``self``.
@@ -290,6 +302,14 @@ class NumpyTensor(Tensor):
         """
         return self.data.ctypes.data
     
+    def _assign(self, other, avoid_deep_copy):
+        """Assign the values of ``other``, which is assumed to be in the
+        same space, to ``self``."""
+        if avoid_deep_copy:
+            self.__data = other.__data
+        else:
+            self.__data[:] = other.__data
+
     ######### Public methods #########        
     def copy(self):
         """Return an identical (deep) copy of this tensor.

--- a/odl/space/npy_tensors.py
+++ b/odl/space/npy_tensors.py
@@ -45,8 +45,8 @@ numpy_array_backend = ArrayBackend(
       ]},
     array_namespace = xp,
     array_constructor = np.array,
-    array_type = np.ndarray
-    
+    array_type = np.ndarray,
+    identifier_of_dtype = lambda dt: str(dt)
  )
 
 _BLAS_DTYPES = (np.dtype('float32'), np.dtype('float64'),
@@ -260,14 +260,6 @@ class NumpyTensorSpace(TensorSpace):
         return 'numpy'
 
     ######### public methods #########
-    def get_dtype_identifier(self, **kwargs):
-        if 'array' in kwargs:
-            assert 'dtype' not in kwargs, 'array and dtype are multually exclusive parameters'
-            return kwargs['array'].dtype.name
-        if 'dtype' in kwargs:
-            assert 'array' not in kwargs, 'array and dtype are multually exclusive parameters'
-            return str(kwargs['dtype'])
-        raise ValueError("Either 'array' or 'dtype' argument must be provided.")
 
     ######### private methods #########    
 

--- a/odl/space/npy_tensors.py
+++ b/odl/space/npy_tensors.py
@@ -244,6 +244,10 @@ class NumpyTensorSpace(TensorSpace):
         return np.array
     
     @property
+    def array_backend(self) -> ArrayBackend:
+        return numpy_array_backend
+    
+    @property
     def array_namespace(self):
         """Name of the array_namespace"""
         return xp
@@ -257,7 +261,7 @@ class NumpyTensorSpace(TensorSpace):
     
     @property
     def available_dtypes(self):
-        return numpy_array_backend.available_dtypes
+        return self.array_backend.available_dtypes
     
     @property
     def element_type(self):

--- a/odl/space/npy_tensors.py
+++ b/odl/space/npy_tensors.py
@@ -16,7 +16,7 @@ import numpy as np
 from odl.set.space import LinearSpaceElement
 from odl.space.base_tensors import Tensor, TensorSpace
 from odl.util import is_numeric_dtype
-from odl.util.vectorization import ArrayBackend
+from odl.array_API_support import ArrayBackend
 
 import array_api_compat.numpy as xp
 

--- a/odl/space/npy_tensors.py
+++ b/odl/space/npy_tensors.py
@@ -15,13 +15,16 @@ import numpy as np
 
 from odl.space.base_tensors import Tensor, TensorSpace
 from odl.util import is_numeric_dtype
+from odl.util.vectorization import ArrayBackend
 
 import array_api_compat.numpy as xp
 
 __all__ = ('NumpyTensorSpace',)
 
-NUMPY_DTYPES = {
-    key : np.dtype(key) for key in [
+numpy_array_backend = ArrayBackend(
+    impl_identifier = 'numpy',
+    available_dtypes = {
+      key : np.dtype(key) for key in [
         bool,
         "bool",
         "int8",
@@ -39,7 +42,9 @@ NUMPY_DTYPES = {
         complex,        
         "complex64",
         "complex128",
-    ]}
+      ]},
+    array_namespace = xp
+ )
 
 _BLAS_DTYPES = (np.dtype('float32'), np.dtype('float64'),
                 np.dtype('complex64'), np.dtype('complex128'))
@@ -252,7 +257,7 @@ class NumpyTensorSpace(TensorSpace):
     
     @property
     def available_dtypes(self):
-        return NUMPY_DTYPES
+        return numpy_array_backend.available_dtypes
     
     @property
     def element_type(self):

--- a/odl/space/npy_tensors.py
+++ b/odl/space/npy_tensors.py
@@ -43,7 +43,10 @@ numpy_array_backend = ArrayBackend(
         "complex64",
         "complex128",
       ]},
-    array_namespace = xp
+    array_namespace = xp,
+    array_constructor = np.array,
+    array_type = np.ndarray
+    
  )
 
 _BLAS_DTYPES = (np.dtype('float32'), np.dtype('float64'),
@@ -238,12 +241,6 @@ class NumpyTensorSpace(TensorSpace):
 
     ########## Attributes ##########
     @property
-    def array_constructor(self):
-        """Name of the array_constructor of this tensor set.
-        """
-        return np.array
-    
-    @property
     def array_backend(self) -> ArrayBackend:
         return numpy_array_backend
     
@@ -251,17 +248,6 @@ class NumpyTensorSpace(TensorSpace):
     def array_namespace(self):
         """Name of the array_namespace"""
         return xp
-    
-    @property
-    def array_type(self):
-        """Name of the array_type of this tensor set.
-        This relates to the python array api
-        """
-        return np.ndarray
-    
-    @property
-    def available_dtypes(self):
-        return self.array_backend.available_dtypes
     
     @property
     def element_type(self):

--- a/odl/space/npy_tensors.py
+++ b/odl/space/npy_tensors.py
@@ -22,7 +22,7 @@ import array_api_compat.numpy as xp
 __all__ = ('NumpyTensorSpace',)
 
 numpy_array_backend = ArrayBackend(
-    impl_identifier = 'numpy',
+    impl = 'numpy',
     available_dtypes = {
       key : np.dtype(key) for key in [
         bool,

--- a/odl/space/space_utils.py
+++ b/odl/space/space_utils.py
@@ -12,7 +12,7 @@ from __future__ import print_function, division, absolute_import
 import numpy as np
 
 from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
-from odl.util.vectorization import lookup_array_backend
+from odl.array_API_support import lookup_array_backend
 
 from odl.space.base_tensors import default_dtype
 from odl.space.npy_tensors import NumpyTensorSpace

--- a/odl/space/space_utils.py
+++ b/odl/space/space_utils.py
@@ -12,7 +12,9 @@ from __future__ import print_function, division, absolute_import
 import numpy as np
 
 from odl.util.npy_compat import AVOID_UNNECESSARY_COPY
+from odl.util.vectorization import lookup_array_backend
 
+from odl.space.base_tensors import default_dtype
 from odl.space.npy_tensors import NumpyTensorSpace
 from odl.util.utility import AVAILABLE_DTYPES, COMPLEX_DTYPES, FLOAT_DTYPES
 
@@ -204,7 +206,7 @@ def cn(shape, dtype='complex128', impl='numpy', device='cpu', **kwargs):
     return tensor_space(shape, dtype=dtype, impl=impl, device=device, **kwargs)
 
 
-def rn(shape, dtype='float64', impl='numpy', device ='cpu', **kwargs):
+def rn(shape, dtype=None, impl='numpy', device ='cpu', **kwargs):
     """Return a space of real tensors.
 
     Parameters
@@ -251,6 +253,8 @@ def rn(shape, dtype='float64', impl='numpy', device ='cpu', **kwargs):
     tensor_space : Space of tensors with arbitrary scalar data type.
     cn : Complex tensor space.
     """
+    if dtype is None:
+        dtype = default_dtype(lookup_array_backend(str(impl).lower()))
     assert dtype in FLOAT_DTYPES, f'For rn, the type must be float, but got {dtype}'
     return tensor_space(shape, dtype=dtype, impl=impl, device=device, **kwargs)
 

--- a/odl/space/weighting.py
+++ b/odl/space/weighting.py
@@ -495,9 +495,9 @@ def _inner_default(x1, x2):
     if is_real_dtype(x2.dtype):
         return np.vecdot(x1.ravel(), x2.ravel())
     else:
-        # This could also be done with `np.vdot`, which has complex conjugation
-        # built in. That however requires ravelling, and does not as easily
-        # generalize to the Python Array API.
+        # `vecdot` has the complex conjugate on the left argument,
+        # whereas ODL convention is that the inner product should
+        # be linear in the left argument (conjugate in the right).
         return np.vecdot(x2.ravel(), x1.ravel())
 
 

--- a/odl/test/space/tensors_test.py
+++ b/odl/test/space/tensors_test.py
@@ -22,7 +22,7 @@ from odl.space.npy_tensors import (
 from odl.util.testutils import (
     all_almost_equal, all_equal, noise_array, noise_element, noise_elements,
     simple_fixture)
-from odl.util.vectorization import lookup_array_backend
+from odl.array_API_support import lookup_array_backend
 from odl.util.ufuncs import UFUNCS
 
 # --- Test helpers --- #

--- a/odl/test/space/tensors_test.py
+++ b/odl/test/space/tensors_test.py
@@ -22,6 +22,7 @@ from odl.space.npy_tensors import (
 from odl.util.testutils import (
     all_almost_equal, all_equal, noise_array, noise_element, noise_elements,
     simple_fixture)
+from odl.util.vectorization import lookup_array_backend
 from odl.util.ufuncs import UFUNCS
 
 # --- Test helpers --- #
@@ -1052,6 +1053,7 @@ def test_conj(tspace):
 def test_array_weighting_init(odl_tspace_impl, exponent):
     """Test initialization of array weightings."""
     impl = odl_tspace_impl
+    array_backend = lookup_array_backend(impl)
     space = odl.rn(DEFAULT_SHAPE, impl=impl)
     weight_arr = _pos_array(space)
     weight_elem = space.element(weight_arr)
@@ -1059,8 +1061,8 @@ def test_array_weighting_init(odl_tspace_impl, exponent):
     weighting_arr  = odl.space_weighting(impl, weight=weight_arr, exponent=exponent)
     weighting_elem = odl.space_weighting(impl, weight=weight_elem, exponent=exponent)
 
-    assert isinstance(weighting_arr.weight, space.array_type)
-    assert isinstance(weighting_elem.weight, space.array_type)
+    assert isinstance(weighting_arr.weight, array_backend.array_type)
+    assert isinstance(weighting_elem.weight, array_backend.array_type)
 
 
 def test_array_weighting_array_is_valid(odl_tspace_impl):

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -18,7 +18,8 @@ import numpy as np
 
 __all__ = ('is_valid_input_array', 'is_valid_input_meshgrid',
            'out_shape_from_meshgrid', 'out_shape_from_array',
-           'OptionalArgDecorator', 'vectorize')
+           'OptionalArgDecorator', 'vectorize',
+           'ArrayBackend', 'lookup_array_backend')
 
 
 def is_valid_input_array(x, ndim=None):
@@ -295,15 +296,18 @@ class _NumpyVectorizeWrapper(object):
 
 
 
-registered_array_backends = {}
+_registered_array_backends = {}
 
 @dataclass
 class ArrayBackend:
-    impl_identifier: str
+    impl: str
     array_namespace: ModuleType
     available_dtypes: dict[str, object]
     def __post_init__(self):
-        registered_array_backends[self.impl_identifier] = self
+        _registered_array_backends[self.impl] = self
+
+def lookup_array_backend(impl: str) -> ArrayBackend:
+    return _registered_array_backends[impl]
 
 
 if __name__ == '__main__':

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -11,16 +11,12 @@
 from __future__ import print_function, division, absolute_import
 from builtins import object
 from functools import wraps
-from dataclasses import dataclass
-from types import ModuleType
-from typing import Callable
 import numpy as np
 
 
 __all__ = ('is_valid_input_array', 'is_valid_input_meshgrid',
            'out_shape_from_meshgrid', 'out_shape_from_array',
-           'OptionalArgDecorator', 'vectorize',
-           'ArrayBackend', 'lookup_array_backend')
+           'OptionalArgDecorator', 'vectorize')
 
 
 def is_valid_input_array(x, ndim=None):
@@ -295,34 +291,6 @@ class _NumpyVectorizeWrapper(object):
         else:
             out[:] = self.vfunc(*x, **kwargs)
 
-
-
-_registered_array_backends = {}
-
-@dataclass
-class ArrayBackend:
-    impl: str
-    array_namespace: ModuleType
-    available_dtypes: dict[str, object]
-    array_type: type
-    array_constructor: Callable
-    identifier_of_dtype: Callable[object, str]
-    def __post_init__(self):
-        if self.impl in _registered_array_backends:
-            raise KeyError(f"An array-backend with the identifier {self.impl} is already registered."
-                          + " Every backend needs to have a unique identifier.")
-        _registered_array_backends[self.impl] = self
-    def get_dtype_identifier(self, **kwargs):
-        if 'array' in kwargs:
-            assert 'dtype' not in kwargs, 'array and dtype are multually exclusive parameters'
-            return self.identifier_of_dtype(kwargs['array'].dtype)
-        if 'dtype' in kwargs:
-            assert 'array' not in kwargs, 'array and dtype are multually exclusive parameters'
-            return self.identifier_of_dtype(kwargs['dtype'])
-        raise ValueError("Either 'array' or 'dtype' argument must be provided.")
-
-def lookup_array_backend(impl: str) -> ArrayBackend:
-    return _registered_array_backends[impl]
 
 
 if __name__ == '__main__':

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -13,6 +13,7 @@ from builtins import object
 from functools import wraps
 from dataclasses import dataclass
 from types import ModuleType
+from typing import Callable
 import numpy as np
 
 
@@ -304,9 +305,18 @@ class ArrayBackend:
     array_namespace: ModuleType
     available_dtypes: dict[str, object]
     array_type: type
-    array_constructor: callable
+    array_constructor: Callable
+    identifier_of_dtype: Callable[object, str]
     def __post_init__(self):
         _registered_array_backends[self.impl] = self
+    def get_dtype_identifier(self, **kwargs):
+        if 'array' in kwargs:
+            assert 'dtype' not in kwargs, 'array and dtype are multually exclusive parameters'
+            return self.identifier_of_dtype(kwargs['array'].dtype)
+        if 'dtype' in kwargs:
+            assert 'array' not in kwargs, 'array and dtype are multually exclusive parameters'
+            return self.identifier_of_dtype(kwargs['dtype'])
+        raise ValueError("Either 'array' or 'dtype' argument must be provided.")
 
 def lookup_array_backend(impl: str) -> ArrayBackend:
     return _registered_array_backends[impl]

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -308,6 +308,9 @@ class ArrayBackend:
     array_constructor: Callable
     identifier_of_dtype: Callable[object, str]
     def __post_init__(self):
+        if self.impl in _registered_array_backends:
+            raise KeyError(f"An array-backend with the identifier {self.impl} is already registered."
+                          + " Every backend needs to have a unique identifier.")
         _registered_array_backends[self.impl] = self
     def get_dtype_identifier(self, **kwargs):
         if 'array' in kwargs:

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -303,6 +303,8 @@ class ArrayBackend:
     impl: str
     array_namespace: ModuleType
     available_dtypes: dict[str, object]
+    array_type: type
+    array_constructor: callable
     def __post_init__(self):
         _registered_array_backends[self.impl] = self
 

--- a/odl/util/vectorization.py
+++ b/odl/util/vectorization.py
@@ -11,6 +11,8 @@
 from __future__ import print_function, division, absolute_import
 from builtins import object
 from functools import wraps
+from dataclasses import dataclass
+from types import ModuleType
 import numpy as np
 
 
@@ -290,6 +292,18 @@ class _NumpyVectorizeWrapper(object):
             return self.vfunc(*x, **kwargs)
         else:
             out[:] = self.vfunc(*x, **kwargs)
+
+
+
+registered_array_backends = {}
+
+@dataclass
+class ArrayBackend:
+    impl_identifier: str
+    array_namespace: ModuleType
+    available_dtypes: dict[str, object]
+    def __post_init__(self):
+        registered_array_backends[self.impl_identifier] = self
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We talked about this a few times already: the various "list of available dtypes" etc methods are _needed_ in `TensorSpace` due to Array API generalisation, but they don't really _belong_ to specific mathematical spaces. Instead, they should be associated to the backend and e.g. every NumPy-based space should simply refer to them. This makes both the tensor spaces themselves simpler and helps with something like `DiscretizedSpace`.